### PR TITLE
feature(new-thing-replacement): Open NewThingReplacement up to public for extension

### DIFF
--- a/Source/NewThing/NewThingFrame.cs
+++ b/Source/NewThing/NewThingFrame.cs
@@ -38,7 +38,7 @@ namespace Replace_Stuff.NewThing
 		}
 	}
 	[StaticConstructorOnStartup]
-	static class NewThingReplacement
+	public static class NewThingReplacement
 	{
 		public class Replacement
 		{


### PR DESCRIPTION
This PR is to add the feature request in #28 

I'm interested in making a small mod to add the Replace Stuff functionality to Save Our Ship 2 and rather than reimplementing Replace Stuff or forking it I'd like to be able to hook in and just add new `Replacement`'s to the `NewThingReplacement.replacements` list after Replace Stuff has already loaded. I did a quick test locally (I removed walls being repalced by doors from the main plugin and just added it back in with a second plugin) and it works. All that's needed is making this class public