### PR TITLE
Quick optimisations of methods called frequently

### DIFF
--- a/Source/Replace/DisableThings.cs
+++ b/Source/Replace/DisableThings.cs
@@ -16,10 +16,21 @@ namespace Replace_Stuff.Replace
 	{
 		public static bool IsReplacing(Thing thing)
 		{
-			return thing != null && thing.Spawned &&
-				thing.Position.GetThingList(thing.Map)
-				.Any(t => (t is ReplaceFrame rf && rf.oldThing == thing && rf.workDone > 0)
-					|| (t is Frame f && f.CanReplace(thing) && f.workDone > 0));
+			if (thing is null || !thing.Spawned) return false;
+
+			var tileThings = thing.Position.GetThingList(thing.Map);
+			if (tileThings.Count <= 1) return false;
+
+			for (int i = 0; i < tileThings.Count; i++)
+			{
+				var tileThing = tileThings[i];
+				if (tileThing == thing) continue;
+
+				if (tileThing is ReplaceFrame rf && rf.workDone > 0 && rf.oldThing == thing) return true;
+				if (tileThing is Frame fr && fr.workDone > 0 && fr.CanReplace(thing)) return true;
+			}
+			
+			return false;
 		}
 	}
 
@@ -39,6 +50,11 @@ namespace Replace_Stuff.Replace
 		//public virtual bool UsableNow
 		public static void Postfix(ref bool __result, Building_WorkTable __instance)
 		{
+			if (!__result)
+			{
+				return;
+			}
+			
 			if (DisableThing.IsReplacing(__instance))
 			{
 				__result = false;


### PR DESCRIPTION
Some quick optimisations, mostly just removing linq to remove allocations. Some numbers:
Left is the prior numbers, right is the current following this patch.

In total ~8% faster per frame (Frame time = one update cycle for rimworld, in this case at 3x, so multiple ticks elapsed during this period)
![Total](https://user-images.githubusercontent.com/48577820/201238774-bd02e05c-707f-499a-b51a-eae75a0e8ed1.png)

The impact of the `IsReplacing` changes for the prior most noticeably slow method method (`IsDisabled` for workbenches)
![IsRepl](https://user-images.githubusercontent.com/48577820/201238786-9b010daf-b185-4fa2-8fac-923fa083e664.png)
